### PR TITLE
Fix the signature of listen's onError callback

### DIFF
--- a/lib/websok.dart
+++ b/lib/websok.dart
@@ -71,7 +71,7 @@ abstract class Websok<C extends WebSocketChannel> {
   /// Listens for different events and executes their callback.
   void listen({
     void onData(dynamic message),
-    void onError(),
+    void onError(error),
     void onDone(),
     bool cancelOnError,
   }) =>


### PR DESCRIPTION
This PR fixes the exception below when trying to use listen with an onError callback. Only includes the error as I don't think the stack trace is of interest.

```
Invalid argument(s): handleError callback must take either an Object (the error), or both an Object (the error) and a StackTrace
```